### PR TITLE
simplify user-config in Containerfiles

### DIFF
--- a/bootc/lamp/Containerfile
+++ b/bootc/lamp/Containerfile
@@ -5,15 +5,11 @@ RUN dnf -y update; dnf install -y httpd mariadb mariadb-server php-fpm php-mysql
 ADD var var
 RUN systemctl enable httpd mariadb php-fpm
 
-# The following configures root user access.
-# Add ssh public keys to /user/etc-system/root.keys as is done below,
-# or, to give root user access via password "secure" (not recommended), uncomment the 2 lines below
-#RUN echo "root:secure" | chpasswd
-#
-#Substitute YOUR public key for the below-private key holder for the following public key will have root access
+# Substitute YOUR public key below-private key holder for the following public key will have root access
+# Alternatively, this section can be removed if configuring users with kickstart or bootc-image-builder
 RUN mkdir /usr/etc-system && \
     echo 'AuthorizedKeysFile /usr/etc-system/%u.keys' >> /etc/ssh/sshd_config.d/30-auth-system.conf && \
-    echo 'ssh-rsa AAAAB3NzaC1yc2EAAAABIwAAAQEA2vfgIjZRMlDQ0ck5ub8S2sfgG1HTML3Y8lsA3yOz/UsVJY/vxnDVrLLZPNk3hLSAVP+W9+j+pF1XsnjQ6aVbrsSxuGkFQvJoZeK3EjZ0A55lqEvJPG9+IUi7rqHBh5yU/ZX9fQ6KkvmB2ECGR1CqOR1uednPJJ/7fHeTElycgOGlYT6hafuo5RV6O3GITA4VAKZdIE+0+N37p0Yej+vIVYG4iRZ7Jgk+ZnZlwyi8IG06CJfuGwpAw76c/rvI6GYYueFwfGjUxo474ReNn53GyBGnM9NtoBdWGFSiPeET7056kfV4TSNDMB24js8lrho3TqE3wl+szkBeKU3oAZ9okQ== dwalsh@localhost.localdomain' > /usr/etc-system/root.keys && chmod 0600 /usr/etc-system/root.keys
+    echo 'ssh-rsa AAAAB3.....' > /usr/etc-system/root.keys && chmod 0600 /usr/etc-system/root.keys
 
 # The following steps should be done in the bootc image.
 CMD [ "/sbin/init" ]

--- a/bootc/lamp/Containerfile.fcos
+++ b/bootc/lamp/Containerfile.fcos
@@ -2,13 +2,8 @@ FROM quay.io/fedora/fedora-coreos:testing
 
 RUN rpm-ostree install dnf; dnf -y remove moby-engine; dnf clean all
 
-# The following configures root user access.
-# Add ssh public keys to /user/etc-system/root.keys as is done below,
-# or, to give root user access via password "secure" (not recommended), uncomment the 2 lines below
-#RUN echo "root:secure" | chpasswd
-#
-#Substitute YOUR public key for the below-private key holder for the following public key will have root access
+# Substitute YOUR public key below-private key holder for the following public key will have root access
+# Alternatively, this section can be removed if configuring users with kickstart or bootc-image-builder
 RUN mkdir /usr/etc-system && \
     echo 'AuthorizedKeysFile /usr/etc-system/%u.keys' >> /etc/ssh/sshd_config.d/30-auth-system.conf && \
-    echo 'ssh-rsa AAAAB3NzaC1yc2EAAAABIwAAAQEA2vfgIjZRMlDQ0ck5ub8S2sfgG1HTML3Y8lsA3yOz/UsVJY/vxnDVrLLZPNk3hLSAVP+W9+j+pF1XsnjQ6aVbrsSxuGkFQvJoZeK3EjZ0A55lqEvJPG9+IUi7rqHBh5yU/ZX9fQ6KkvmB2ECGR1CqOR1uednPJJ/7fHeTElycgOGlYT6hafuo5RV6O3GITA4VAKZdIE+0+N37p0Yej+vIVYG4iRZ7Jgk+ZnZlwyi8IG06CJfuGwpAw76c/rvI6GYYueFwfGjUxo474ReNn53GyBGnM9NtoBdWGFSiPeET7056kfV4TSNDMB24js8lrho3TqE3wl+szkBeKU3oAZ9okQ== dwalsh@localhost.localdomain' > /usr/etc-system/root.keys && chmod 0600 /usr/etc-system/root.keys
-
+    echo 'ssh-rsa AAAAB3.....' > /usr/etc-system/root.keys && chmod 0600 /usr/etc-system/root.keys

--- a/bootc/machine/Containerfile
+++ b/bootc/machine/Containerfile
@@ -16,15 +16,11 @@ USER core
 RUN systemctl --user enable podman.socket
 USER root
 
-# The following configures root user access.
-# Add ssh public keys to /user/etc-system/root.keys as is done below,
-# or, to give root user access via password "secure" (not recommended), uncomment the 2 lines below
-#RUN echo "root:secure" | chpasswd
-#
-#Substitute YOUR public key for the below-private key holder for the following public key will have root access
+# Substitute YOUR public key below-private key holder for the following public key will have root access
+# Alternatively, this section can be removed if configuring users with kickstart or bootc-image-builder
 RUN mkdir /usr/etc-system && \
     echo 'AuthorizedKeysFile /usr/etc-system/%u.keys' >> /etc/ssh/sshd_config.d/30-auth-system.conf && \
-    echo 'ssh-rsa AAAAB3NzaC1yc2EAAAABIwAAAQEA2vfgIjZRMlDQ0ck5ub8S2sfgG1HTML3Y8lsA3yOz/UsVJY/vxnDVrLLZPNk3hLSAVP+W9+j+pF1XsnjQ6aVbrsSxuGkFQvJoZeK3EjZ0A55lqEvJPG9+IUi7rqHBh5yU/ZX9fQ6KkvmB2ECGR1CqOR1uednPJJ/7fHeTElycgOGlYT6hafuo5RV6O3GITA4VAKZdIE+0+N37p0Yej+vIVYG4iRZ7Jgk+ZnZlwyi8IG06CJfuGwpAw76c/rvI6GYYueFwfGjUxo474ReNn53GyBGnM9NtoBdWGFSiPeET7056kfV4TSNDMB24js8lrho3TqE3wl+szkBeKU3oAZ9okQ== dwalsh@localhost.localdomain' > /usr/etc-system/root.keys && chmod 0600 /usr/etc-system/root.keys
+    echo 'ssh-rsa AAAAB3.....' > /usr/etc-system/root.keys && chmod 0600 /usr/etc-system/root.keys
 
 # The following steps should be done in the bootc image.
 CMD [ "/sbin/init" ]

--- a/bootc/machine/Containerfile.fcos
+++ b/bootc/machine/Containerfile.fcos
@@ -2,12 +2,8 @@ FROM quay.io/fedora/fedora-coreos:testing
 
 RUN rpm-ostree install dnf; dnf -y remove moby-engine; dnf clean all
 
-# The following configures root user access.
-# Add ssh public keys to /user/etc-system/root.keys as is done below,
-# or, to give root user access via password "secure" (not recommended), uncomment the 2 lines below
-#RUN echo "root:secure" | chpasswd
-#
-#Substitute YOUR public key for the below-private key holder for the following public key will have root access
+# Substitute YOUR public key below-private key holder for the following public key will have root access
+# Alternatively, this section can be removed if configuring users with kickstart or bootc-image-builder
 RUN mkdir /usr/etc-system && \
     echo 'AuthorizedKeysFile /usr/etc-system/%u.keys' >> /etc/ssh/sshd_config.d/30-auth-system.conf && \
-    echo 'ssh-rsa AAAAB3NzaC1yc2EAAAABIwAAAQEA2vfgIjZRMlDQ0ck5ub8S2sfgG1HTML3Y8lsA3yOz/UsVJY/vxnDVrLLZPNk3hLSAVP+W9+j+pF1XsnjQ6aVbrsSxuGkFQvJoZeK3EjZ0A55lqEvJPG9+IUi7rqHBh5yU/ZX9fQ6KkvmB2ECGR1CqOR1uednPJJ/7fHeTElycgOGlYT6hafuo5RV6O3GITA4VAKZdIE+0+N37p0Yej+vIVYG4iRZ7Jgk+ZnZlwyi8IG06CJfuGwpAw76c/rvI6GYYueFwfGjUxo474ReNn53GyBGnM9NtoBdWGFSiPeET7056kfV4TSNDMB24js8lrho3TqE3wl+szkBeKU3oAZ9okQ== dwalsh@localhost.localdomain' > /usr/etc-system/root.keys && chmod 0600 /usr/etc-system/root.keys
+    echo 'ssh-rsa AAAAB3.....' > /usr/etc-system/root.keys && chmod 0600 /usr/etc-system/root.keys


### PR DESCRIPTION
@rhatdan this PR simplifies the root user configuration (and adds note about kickstart and bib option)
