### PR TITLE
Fixing issue where parens are used where brackets are needed

### DIFF
--- a/bootc/podman.sh
+++ b/bootc/podman.sh
@@ -89,10 +89,10 @@ function init {
     clear
 }
 
-function ctr (
+function ctr {
     echo -n $step
     ((step+=1))
-)
+}
 
 function build {
     echo_color "


### PR DESCRIPTION
Signed-off-by: Liz Blanchard <lblanchard@redhat.com>

Script won't run since ctr function throws newline error.