### PR TITLE
bootc: improvements to demo script and library

### DIFF
--- a/bootc/lamp/podman.sh
+++ b/bootc/lamp/podman.sh
@@ -19,7 +19,7 @@ Build bootable OCI Image"
     exec_color "cat $APP/Containerfile"
 
     exec_color "podman manifest exists ${IMAGE} && podman manifest rm ${IMAGE} || podman rmi --force ${IMAGE}"
-    exec_color "podman build --build-arg=\"SSHPUBKEY=$(cat $HOME/.ssh/id_rsa.pub)\" --arch=${ARCH} $FROM--manifest ${IMAGE} $APP/"
+    exec_color "podman build --build-arg=\"SSHPUBKEY=$(cat "${HOME}/.ssh/id_rsa.pub")\" --arch=${ARCH} $FROM--manifest ${IMAGE} $APP/"
 }
 
 function test_crun_vm {
@@ -55,13 +55,13 @@ case "${1:-""}" in
 	demo
 	;;
     3)
-	create_disk_image "--type $TYPE --type ami"
-	rename $TYPE
+	create_disk_image "--type ${TYPE} --type ami"
+	rename "${TYPE}"
 	rename ami
 	test_crun_vm
 	;;
     4)
-	create_manifest $TYPE
+	create_manifest "${TYPE}"
 	create_manifest ami
 	push_manifest
 	inspect

--- a/bootc/lamp/podman.sh
+++ b/bootc/lamp/podman.sh
@@ -23,6 +23,9 @@ Build bootable OCI Image"
 }
 
 function test_crun_vm {
+    if ! command -v crun-vm; then
+        sudo bash -c "dnf -y install crun-vm"
+    fi
     echo_color "
 Test VM using crun-vm"
     tmpdir=$(mktemp -d /tmp/podman.demo-XXXXX);

--- a/bootc/lamp/podman.sh
+++ b/bootc/lamp/podman.sh
@@ -2,7 +2,9 @@
 
 DEFAULT_APP="lamp"
 
-. ../podman_helper.sh
+export DEFAULT_APP="lamp"
+
+source ../podman_helper.sh
 
 function build {
     echo_color "

--- a/bootc/lamp/podman.sh
+++ b/bootc/lamp/podman.sh
@@ -54,7 +54,7 @@ case "${1:-""}" in
 	;;
     2)
 	login
-	push
+	push_manifest
 	demo
 	;;
     3)

--- a/bootc/podman_helper.sh
+++ b/bootc/podman_helper.sh
@@ -117,9 +117,14 @@ Time for video
 }
 
 function create_disk_image {
+    if [ -f "${XDG_RUNTIME_DIR}/containers/auth.json" ]; then
+        AUTH_JSON="${XDG_RUNTIME_DIR}/containers/auth.json"
+    else
+        AUTH_JSON="${HOME}/.docker/config.json"
+    fi
     echo_color "
 Creating disk images $1 with bootc-image-builder"
-    exec_color "sudo podman run -v $XDG_RUNTIME_DIR/containers/auth.json:/run/containers/0/auth.json --rm -it --platform=${OS}/${ARCH} --privileged -v .:/output -v ${storedir}:/store --pull newer quay.io/centos-bootc/bootc-image-builder $_TYPE --chown $UID:$UID ${IMAGE} "
+    exec_color "sudo podman run -v ${AUTH_JSON}:/run/containers/0/auth.json --rm -it --platform=${OS}/${ARCH} --privileged -v .:/output -v ${storedir}:/store --pull newer quay.io/centos-bootc/bootc-image-builder $1 --chown ${UID}:${UID} ${IMAGE} "
 }
 
 function rename {

--- a/bootc/podman_helper.sh
+++ b/bootc/podman_helper.sh
@@ -1,3 +1,5 @@
+#!/bin/bash
+
 set -eou pipefail
 IFS=$'\n\t'
 

--- a/bootc/podman_helper.sh
+++ b/bootc/podman_helper.sh
@@ -77,9 +77,6 @@ Invalid option: -${OPTARG}."
   esac
 done
 
-# shift all the args so we can use positional args after the flags (i.e. ./podman.sh -r string -A string 1)
-shift $((OPTIND - 1));
-
 REGISTRY=${REGISTRY:-${DEFAULT_REGISTRY}}
 APP=${APP:-${DEFAULT_APP}}
 ARCH=${ARCH:-${DEFAULT_ARCH}}

--- a/bootc/podman_helper.sh
+++ b/bootc/podman_helper.sh
@@ -128,10 +128,9 @@ Creating disk images $1 with bootc-image-builder"
 }
 
 function rename {
-    _TYPE=$1
     mkdir -p image
-    new_image="image/$(basename "${IMAGE}").${_TYPE}"
-    exec_color "mv ${_TYPE}/disk.${_TYPE} ${new_image} 2>/dev/null || mv image/disk.* ${new_image}"
+    new_image="image/$(basename "${IMAGE}").${TYPE}"
+    exec_color "mv ${TYPE}/disk.${TYPE} ${new_image} 2>/dev/null || mv image/disk.* ${new_image}"
     exec_color "zstd -f --rm ${new_image}"
 }
 
@@ -150,9 +149,8 @@ Modify OCI Image ${IMAGE} to support nvidia"
 function create_manifest {
     echo_color "
 Populate OCI manifest with artifact $1"
-    _TYPE=$1
-    new_image="image/$(basename "${IMAGE}").${_TYPE}.zst"
-    exec_color "podman manifest add ${VARIANT} --os ${OS} --arch=${ARCH} --artifact --artifact-type application/x-qemu-disk --annotation disktype=${_TYPE} ${IMAGE} ${new_image}"
+    new_image="image/$(basename "${IMAGE}").${TYPE}.zst"
+    exec_color "podman manifest add ${VARIANT} --os ${OS} --arch=${ARCH} --artifact --artifact-type application/x-qemu-disk --annotation disktype=${TYPE} ${IMAGE} ${new_image}"
 }
 
 function push_manifest {

--- a/bootc/podman_helper.sh
+++ b/bootc/podman_helper.sh
@@ -99,7 +99,7 @@ function init {
 function login {
     echo_color "
 Push generated manifest to container registry"
-    exec_color "podman login $REGISTRY"
+    exec_color "podman login ${REGISTRY}"
 }
 
 function push {
@@ -125,7 +125,7 @@ Creating disk images $1 with bootc-image-builder"
 function rename {
     _TYPE=$1
     mkdir -p image
-    new_image="image/$(basename ${IMAGE}).${_TYPE}"
+    new_image="image/$(basename "${IMAGE}").${_TYPE}"
     exec_color "mv ${_TYPE}/disk.${_TYPE} ${new_image} 2>/dev/null || mv image/disk.* ${new_image}"
     exec_color "zstd -f --rm ${new_image}"
 }
@@ -146,7 +146,7 @@ function create_manifest {
     echo_color "
 Populate OCI manifest with artifact $1"
     _TYPE=$1
-    new_image="image/$(basename ${IMAGE}).${_TYPE}.zst"
+    new_image="image/$(basename "${IMAGE}").${_TYPE}.zst"
     exec_color "podman manifest add ${VARIANT} --os ${OS} --arch=${ARCH} --artifact --artifact-type application/x-qemu-disk --annotation disktype=${_TYPE} ${IMAGE} ${new_image}"
 }
 


### PR DESCRIPTION
This is a collection of fixes I worked through on my Fedora Silverblue system to get the first 3 demos in the `lamp/podman.sh` script to succeed (mostly).

More ShellCheck fixes, but also some additional logic around the credentials and testing for `crun-vm`.

See individual commits for more details.